### PR TITLE
feat: create new component and hook to handle file download (#26)

### DIFF
--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clevercanary/data-explorer-ui",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@clevercanary/data-explorer-ui",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@next/eslint-plugin-next": "^13.1.6",

--- a/packages/data-explorer-ui/package.json
+++ b/packages/data-explorer-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevercanary/data-explorer-ui",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "scripts": {
     "test": "jest",

--- a/packages/data-explorer-ui/src/components/common/Button/components/FileDownloadButton/fileDownloadButton.tsx
+++ b/packages/data-explorer-ui/src/components/common/Button/components/FileDownloadButton/fileDownloadButton.tsx
@@ -1,0 +1,27 @@
+import { Box } from "@mui/material";
+import React, { useEffect, useRef } from "react";
+
+export interface FileDownloadButtonProps {
+  fileName?: string;
+  fileUrl?: string;
+}
+
+export const FileDownloadButton = ({
+  fileName,
+  fileUrl,
+}: FileDownloadButtonProps): JSX.Element => {
+  const downloadRef = useRef<HTMLAnchorElement>(null);
+
+  // Initiates file download when file url request is successful.
+  useEffect(() => {
+    if (downloadRef.current && fileName && fileUrl) {
+      downloadRef.current.setAttribute("href", fileUrl);
+      downloadRef.current.setAttribute("download", fileName);
+      downloadRef.current.click();
+    }
+  }, [fileName, fileUrl]);
+
+  return (
+    <Box component="a" download ref={downloadRef} sx={{ display: "none" }} />
+  );
+};

--- a/packages/data-explorer-ui/src/components/common/ButtonGroup/buttonGroup.tsx
+++ b/packages/data-explorer-ui/src/components/common/ButtonGroup/buttonGroup.tsx
@@ -3,7 +3,8 @@ import {
   ButtonGroup as MButtonGroup,
   ButtonGroupProps as MButtonGroupProps,
 } from "@mui/material";
-import React, { ElementType, ReactNode } from "react";
+import React, { ReactNode } from "react";
+import { LoadingIcon } from "../CustomIcon/components/LoadingIcon/loadingIcon";
 
 /**
  * An extension of the basic Mui ButtonGroup component with available ButtonGroup props.
@@ -13,7 +14,8 @@ export type OnButtonGroupButtonFn = () => void; // Function invoked with button 
 
 export interface ButtonGroup {
   action: string; // Short description to describe button action.
-  label: ElementType | string; // Button label may be an element i.e. icon.
+  label: ReactNode; // Button label may be a string or an element e.g. icon.
+  loading?: boolean;
   onClick: OnButtonGroupButtonFn;
 }
 
@@ -45,26 +47,13 @@ export const ButtonGroup = ({
       size={size}
       variant={variant}
     >
-      {buttons.map(({ action, label, onClick }) => {
+      {buttons.map(({ action, label, loading, onClick }) => {
         return (
-          <MButton key={action} onClick={onClick}>
-            {renderButtonLabel(label)}
+          <MButton key={action} onClick={loading ? undefined : onClick}>
+            {loading ? <LoadingIcon fontSize="small" /> : label}
           </MButton>
         );
       })}
     </MButtonGroup>
   );
 };
-
-/**
- * Renders button label.
- * @param label - Label is a string or element type.
- * @returns react node for the displaying of button label.
- */
-function renderButtonLabel(label: ElementType | string): ReactNode {
-  if (typeof label === "string") {
-    return label;
-  }
-  const Label = label;
-  return <Label />;
-}

--- a/packages/data-explorer-ui/src/hooks/useFileLocation.ts
+++ b/packages/data-explorer-ui/src/hooks/useFileLocation.ts
@@ -1,0 +1,35 @@
+import { API_FILE_LOCATION_FETCH } from "../apis/azul/common/constants";
+import {
+  useRequestFileLocation,
+  UseRequestFileLocationResult,
+} from "./useRequestFileLocation";
+
+export interface UseFileLocation extends UseRequestFileLocationResult {
+  fileUrl?: string;
+}
+
+export const useFileLocation = (fileUrl?: string): UseFileLocation => {
+  // Prepend "/fetch" to the path of the specified file URL, if not already included.
+  const url = buildFetchFileUrl(fileUrl);
+  const fileLocation = useRequestFileLocation(url);
+  const { data } = fileLocation;
+  const { location } = data || {};
+  return { ...fileLocation, fileUrl: location };
+};
+
+/**
+ * Prepends "/fetch" to the path of the specified file URL, if not already included.
+ * @param fileUrl - File url.
+ * @returns file url with path prepended with "/fetch".
+ */
+function buildFetchFileUrl(fileUrl?: string): string | undefined {
+  if (!fileUrl) {
+    return;
+  }
+  const url = new URL(fileUrl);
+  const path = url.pathname;
+  if (!path.includes(API_FILE_LOCATION_FETCH)) {
+    url.pathname = `${API_FILE_LOCATION_FETCH}${path}`;
+  }
+  return url.toString();
+}

--- a/packages/data-explorer-ui/src/hooks/useRequestFileLocation.ts
+++ b/packages/data-explorer-ui/src/hooks/useRequestFileLocation.ts
@@ -12,7 +12,7 @@ export interface FileLocation {
   status: number;
 }
 
-interface UseRequestFileLocationResult {
+export interface UseRequestFileLocationResult {
   data: FileLocation | undefined;
   isIdle: boolean;
   isLoading: boolean;


### PR DESCRIPTION
Closes #26 

- New hook to handle special case where file url path may not include required `/fetch`.
- New button component to handle file downloads.
- Updates to `ButtonGroup` component to support a "loading" state.
  - Includes change in type for buttons prop `label`. 