### PR TITLE
fix: corrected package lock version #839

### DIFF
--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clevercanary/data-explorer-ui",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@clevercanary/data-explorer-ui",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@next/eslint-plugin-next": "^13.1.6",


### PR DESCRIPTION
Closes clevercanary/data-browser#839.