### PR TITLE
fix: updated patch version #839

### DIFF
--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clevercanary/data-explorer-ui",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@clevercanary/data-explorer-ui",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@next/eslint-plugin-next": "^13.1.6",

--- a/packages/data-explorer-ui/package.json
+++ b/packages/data-explorer-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevercanary/data-explorer-ui",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Closes clevercanary/data-browser#839.