### PR TITLE
feat: add missing alert variants (#106)

### DIFF
--- a/packages/data-explorer-ui/src/components/common/Alert/alert.tsx
+++ b/packages/data-explorer-ui/src/components/common/Alert/alert.tsx
@@ -12,7 +12,7 @@ export interface AlertProps {
   icon?: MAlertProps["icon"];
   severity: MAlertProps["severity"];
   title?: ReactNode;
-  variant?: MAlertProps["variant"];
+  variant?: MAlertProps["variant"] | "banner" | "neutral";
 }
 
 export const Alert = ({


### PR DESCRIPTION
I couldn't figure out how to do it automatically, more details in the issue itself. 