### PR TITLE
feat: using axios to handle api calls #107

### DIFF
--- a/packages/data-explorer-ui/src/entity/api/service.ts
+++ b/packages/data-explorer-ui/src/entity/api/service.ts
@@ -15,7 +15,6 @@ import { FilterState } from "../../hooks/useCategoryFilter";
 import {
   getDefaultDetailParams,
   getDefaultListParams,
-  getURL,
 } from "../../shared/utils";
 import { convertUrlParams } from "../../utils/url";
 import { api } from "./client";
@@ -43,7 +42,7 @@ export const fetchEntitiesFromQuery = async (
 ): Promise<AzulEntitiesResponse> => {
   const params = { ...getDefaultListParams(), ...listParams };
   return await fetchEntitiesFromURL(
-    `${getURL()}${apiPath}?${convertUrlParams(params)}`,
+    `${apiPath}?${convertUrlParams(params)}`,
     accessToken
   );
 };
@@ -100,7 +99,7 @@ export const fetchEntityDetail = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this response type can't be determined beforehand
 ): Promise<any> => {
   const res = await api().get(
-    `${getURL()}${apiPath}/${id}?${convertUrlParams({ ...param })}`
+    `${apiPath}/${id}?${convertUrlParams({ ...param })}`
   );
   return res.data;
 };
@@ -132,7 +131,7 @@ export const fetchSummary = async (
 
   const options = createFetchOptions(accessToken);
   const res = await api().get<AzulSummaryResponse>(
-    `${getURL()}${apiPath}?${convertUrlParams({ ...summaryParams })}`,
+    `${apiPath}?${convertUrlParams({ ...summaryParams })}`,
     options
   );
   return res.data;


### PR DESCRIPTION
Closes #107 

Replacing the use of fetch to axios.

OBS: It seems that API's catalogs have changed. **I was only able to test this with dev:hca-dpc** and had to change the catalog to dcp3. I have tried to use the `data-explore`s current version to check if the error was related to something that I did on this PR, but error happens on that version as well.