### PR TITLE
fix: only update related view if configured (#200)

### DIFF
--- a/packages/data-explorer-ui/src/hooks/useEntityListRelatedView.ts
+++ b/packages/data-explorer-ui/src/hooks/useEntityListRelatedView.ts
@@ -56,15 +56,23 @@ export const useEntityListRelatedView = (): void => {
   }, [relatedSearchFn, resultKey, run, searchKey, selectedCategoryValues]);
 
   useEffect(() => {
-    exploreDispatch({
-      payload: {
-        relatedListItems: buildRelatedEntityList(
-          listItems,
-          relatedSearchResult,
-          selectedCategoryValues
-        ),
-      },
-      type: ExploreActionKind.ProcessRelatedResponse,
-    });
-  }, [exploreDispatch, listItems, relatedSearchResult, selectedCategoryValues]);
+    if (relatedSearchFn) {
+      exploreDispatch({
+        payload: {
+          relatedListItems: buildRelatedEntityList(
+            listItems,
+            relatedSearchResult,
+            selectedCategoryValues
+          ),
+        },
+        type: ExploreActionKind.ProcessRelatedResponse,
+      });
+    }
+  }, [
+    exploreDispatch,
+    listItems,
+    relatedSearchFn,
+    relatedSearchResult,
+    selectedCategoryValues,
+  ]);
 };


### PR DESCRIPTION
The ProcessRelatedResponse action was firing on every tab change even if no relatedSearchFn was configured. 
I updated the related results useEffect to test if the relatedSearchFn exists before sending a ProcessRelatedResponse action.