### PR TITLE
feat: create layout component (#7)

### DIFF
--- a/packages/data-explorer-ui/src/components/Layout/components/ContentLayout/contentLayout.styles.ts
+++ b/packages/data-explorer-ui/src/components/Layout/components/ContentLayout/contentLayout.styles.ts
@@ -1,0 +1,81 @@
+import styled from "@emotion/styled";
+import { textBodyLarge4002Lines } from "../../../../styles/common/mixins/fonts";
+import { DESKTOP_SM, TABLET } from "../../../../theme/common/breakpoints";
+
+const CONTENT_GRID_WIDTH = 734;
+const NAV_MAX_WIDTH = 232;
+const PADDING = 24;
+const PADDING_X = PADDING;
+const PADDING_Y = PADDING;
+
+export const ContentLayout = styled.div`
+  background-color: ${({ theme }) => theme.palette.common.white};
+  display: grid;
+  flex: 1;
+  grid-template-areas: "navigation content outline";
+  grid-template-columns:
+    minmax(360px, auto) minmax(auto, ${CONTENT_GRID_WIDTH}px)
+    minmax(346px, auto);
+  height: 100%;
+  margin: 0 auto;
+
+  ${({ theme }) => theme.breakpoints.down(DESKTOP_SM)} {
+    grid-template-areas: "navigation content";
+    grid-template-columns: ${NAV_MAX_WIDTH + PADDING_X * 2}px fit-content(
+        ${CONTENT_GRID_WIDTH}px
+      );
+  }
+
+  ${({ theme }) => theme.breakpoints.down(TABLET)} {
+    grid-template-areas: "content";
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const NavigationGrid = styled.div`
+  background-color: ${({ theme }) => theme.palette.smoke.light};
+  box-shadow: inset -1px 0 ${({ theme }) => theme.palette.smoke.main};
+  grid-area: navigation;
+
+  ${({ theme }) => theme.breakpoints.down(TABLET)} {
+    display: none;
+  }
+`;
+
+export const ContentGrid = styled.div`
+  grid-area: content;
+`;
+
+export const OutlineGrid = styled.div`
+  grid-area: outline;
+
+  ${({ theme }) => theme.breakpoints.down(DESKTOP_SM)} {
+    display: none;
+  }
+`;
+
+export const Navigation = styled.div`
+  box-sizing: content-box;
+  margin-left: auto;
+  max-width: ${NAV_MAX_WIDTH}px;
+  padding: ${PADDING}px;
+`;
+
+export const Content = styled.div`
+  padding: ${PADDING_Y}px 40px;
+
+  p {
+    ${textBodyLarge4002Lines}
+  }
+
+  ${({ theme }) => theme.breakpoints.down(TABLET)} {
+    padding: ${PADDING_Y}px 16px;
+  }
+`;
+
+export const Outline = styled.div`
+  box-sizing: content-box;
+  margin-right: auto;
+  max-width: 242px;
+  padding: ${PADDING_Y}px 0;
+`;

--- a/packages/data-explorer-ui/src/components/Layout/components/ContentLayout/contentLayout.tsx
+++ b/packages/data-explorer-ui/src/components/Layout/components/ContentLayout/contentLayout.tsx
@@ -1,0 +1,40 @@
+import React, { ReactNode } from "react";
+import {
+  Content,
+  ContentGrid,
+  ContentLayout as Layout,
+  Navigation as NavigationPositioner,
+  NavigationGrid,
+  Outline as OutlinePositioner,
+  OutlineGrid,
+} from "./contentLayout.styles";
+
+export interface ContentLayoutProps {
+  content: ReactNode;
+  navigation?: ReactNode;
+  outline?: ReactNode;
+}
+
+export const ContentLayout = ({
+  content,
+  navigation,
+  outline,
+}: ContentLayoutProps): JSX.Element => {
+  return (
+    <Layout>
+      {navigation && (
+        <NavigationGrid>
+          <NavigationPositioner>{navigation}</NavigationPositioner>
+        </NavigationGrid>
+      )}
+      <ContentGrid>
+        <Content>{content}</Content>
+      </ContentGrid>
+      {outline && (
+        <OutlineGrid>
+          <OutlinePositioner>{outline}</OutlinePositioner>
+        </OutlineGrid>
+      )}
+    </Layout>
+  );
+};

--- a/packages/data-explorer-ui/src/views/ContentView/contentView.tsx
+++ b/packages/data-explorer-ui/src/views/ContentView/contentView.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from "react";
+import { ContentLayout } from "../../components/Layout/components/ContentLayout/contentLayout";
+
+export interface ContentViewProps {
+  content: ReactNode;
+  navigation?: ReactNode;
+  outline?: ReactNode;
+}
+
+export const ContentView = ({
+  content,
+  navigation,
+  outline,
+}: ContentViewProps): JSX.Element => {
+  return (
+    <ContentLayout
+      content={content}
+      navigation={navigation}
+      outline={outline}
+    />
+  );
+};


### PR DESCRIPTION
Closes Databiosphere/findable-ui#7

New layout with centre channel, and left nav created. Scaffolding in place for right nav (even though it was out of scope).
