### PR TITLE
feat: moving page config from data-browser #202

### DIFF
--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -50,6 +50,7 @@
         "@tanstack/react-table": "8.5.11",
         "axios": "1.3.5",
         "copy-to-clipboard": "3.3.1",
+        "csv-parse": "^5.0.4",
         "isomorphic-dompurify": "0.24.0",
         "next": "12.3.1",
         "react": "17.0.2",
@@ -10646,6 +10647,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "node_modules/csv-parse": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.10.tgz",
+      "integrity": "sha512-cTXY6iy0gN5Ha/cGILeDgQE+nKiKDU2m0DjSRdJhr86BN3cM7oefBsTk2aH0LQeaYtL7Z7HvW+jYoadmdhzeDA==",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -30352,6 +30359,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "csv-parse": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.10.tgz",
+      "integrity": "sha512-cTXY6iy0gN5Ha/cGILeDgQE+nKiKDU2m0DjSRdJhr86BN3cM7oefBsTk2aH0LQeaYtL7Z7HvW+jYoadmdhzeDA==",
+      "peer": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/packages/data-explorer-ui/package.json
+++ b/packages/data-explorer-ui/package.json
@@ -62,6 +62,7 @@
     "@tanstack/react-table": "8.5.11",
     "axios": "1.3.5",
     "copy-to-clipboard": "3.3.1",
+    "csv-parse": "^5.0.4",
     "isomorphic-dompurify": "0.24.0",
     "next": "12.3.1",
     "react": "17.0.2",

--- a/packages/data-explorer-ui/src/server/index.ts
+++ b/packages/data-explorer-ui/src/server/index.ts
@@ -1,0 +1,94 @@
+import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
+import { ParsedUrlQuery } from "querystring";
+import { AzulEntitiesStaticResponse } from "../apis/azul/common/entities";
+import { getConfig } from "../config/config";
+import { EntityConfig } from "../config/entities";
+import { getEntityConfig } from "../config/utils";
+import { EMPTY_PAGE } from "../entity/api/constants";
+import { getEntityService } from "../hooks/useEntityService";
+import { database } from "../utils/database";
+import { readFile } from "../utils/tsvParser";
+
+interface PageUrl extends ParsedUrlQuery {
+  entityListType: string;
+}
+
+/**
+ * Seed database.
+ * @param entityListType - Entity list type.
+ * @param entityConfig - Entity config.
+ */
+const seedDatabase = async function seedDatabase( // TODO get rid of this duplicated code
+  entityListType: string,
+  entityConfig: EntityConfig
+): Promise<void> {
+  const { label, staticEntityImportMapper, staticLoadFile } = entityConfig;
+
+  if (!staticLoadFile) {
+    throw new Error(`staticLoadFile not found for entity entity ${label}`);
+  }
+
+  // Build database from configured TSV, if any.
+  const rawData = await readFile(staticLoadFile);
+
+  if (!rawData) {
+    throw new Error(`File ${staticLoadFile} not found for entity ${label}`);
+  }
+
+  const object = JSON.parse(rawData.toString());
+  const entities = staticEntityImportMapper
+    ? Object.values(object).map(staticEntityImportMapper)
+    : Object.values(object);
+
+  // Seed entities.
+  database.get().seed(entityListType, entities);
+};
+
+/**
+ * Build the list of paths to be built statically.
+ * @returns GetStaticPaths function to be used at the nextjs page
+ */
+export const getStaticPaths: GetStaticPaths = async () => {
+  const entities = getConfig().entities;
+  const paths = entities.map((entity) => ({
+    params: {
+      entityListType: entity.route,
+    },
+  }));
+  return {
+    fallback: true, //TODO should this not be false? We have no server...
+    paths,
+  };
+};
+
+/**
+ * Build the set of props for pre-rendering of page.
+ * @param context - Object containing values related to the current context.
+ */
+export const getStaticProps: GetStaticProps<
+  AzulEntitiesStaticResponse
+> = async (context: GetStaticPropsContext) => {
+  const appConfig = getConfig();
+  const { entityListType } = context.params as PageUrl;
+  const { entities } = appConfig;
+  const entityConfig = getEntityConfig(entities, entityListType);
+  const { staticLoad } = entityConfig;
+  const { fetchAllEntities } = getEntityService(entityConfig); // Determine the type of fetch, either from an API endpoint or a TSV.
+
+  // Seed database.
+  if (entityConfig && staticLoad) {
+    await seedDatabase(entityListType, entityConfig);
+  }
+
+  // Fetch the result set from either a configured API endpoint or from a local database seeded from a configured TSV.
+  const resultList = entityConfig.staticLoad
+    ? await fetchAllEntities(entityListType)
+    : EMPTY_PAGE;
+
+  return {
+    props: {
+      data: resultList,
+      entityListType: entityListType,
+    },
+  };
+};

--- a/packages/data-explorer-ui/src/utils/tsvParser.ts
+++ b/packages/data-explorer-ui/src/utils/tsvParser.ts
@@ -1,0 +1,176 @@
+/*
+ * The AnVIL
+ * https://www.anvilproject.org
+ *
+ * Service for AnVIL dashboard file system methods.
+ */
+
+import { CastingContext, parse as parseCsv } from "csv-parse/sync";
+import fs from "fs";
+
+type ReturnType = string | number | boolean;
+
+type FieldKey = string;
+
+/**
+ * Returns the file contents parsed into a model shaped by FIELD, or as row arrays if FIELD is omitted.
+ *
+ * @param content - to be parsed
+ * @param delimiter - csv delimiter
+ * @param FIELD - fields
+ * @param FIELD_TYPE - field types
+ * @returns @see ReturnType[]
+ */
+export const parseContentRows = async function parseContentRows<T>(
+  content: Buffer | string,
+  delimiter = ",",
+  FIELD: { [key: FieldKey]: string },
+  FIELD_TYPE: { [key: FieldKey]: string }
+): Promise<T[]> {
+  if (!FIELD) return parseCsv(content, { delimiter, relax_quotes: true });
+  const keyTypes = Object.fromEntries(
+    Object.entries(FIELD_TYPE).map(([header, type]) => [FIELD[header], type])
+  );
+  return parseCsv(content, {
+    cast: (datum: string, info: CastingContext) =>
+      info.header ? datum : parseDatumValue(datum, keyTypes[info.column]),
+    columns: (row: string[]) => row.map((header: string) => header),
+    delimiter,
+    relax_quotes: true,
+  });
+};
+
+/**
+ * Reads the contents of the specified directory and returns an array of file names.
+ * @param dir - Directory.
+ * @param options - Options.
+ * @returns an array of file names for the specified directory.
+ */
+export const readDir = async function readDir(
+  dir: string,
+  options = null
+): Promise<string[] | undefined> {
+  try {
+    return fs.readdirSync(dir, options);
+    // eslint-disable-next-line no-empty -- copied from readFile function
+  } catch (err) {}
+};
+
+/**
+ * Returns the file content for the specified file.
+ *
+ * @param file - file's path
+ * @param options - file's options
+ */
+export const readFile = async function readFile(
+  file: string,
+  options = null
+): Promise<Buffer | undefined> {
+  try {
+    // const filePath = path.resolve(__dirname, file);
+    // const jsonDirectory = path.join(process.cwd(), "files");
+    const jsonDirectory = process.cwd();
+    return fs.readFileSync(jsonDirectory + "/" + file, options);
+    // eslint-disable-next-line no-empty -- copied from anvil-portal
+  } catch (err) {}
+};
+
+/**
+ * Returns the datum formatted as a string array.
+ *
+ * @param datum - CSV data
+ * @returns data formatted as array
+ */
+function formatDatumAsArray(datum: string): ReturnType[] {
+  if (datum) {
+    const initialValue: string[] = [];
+    return datum.split(",").reduce((acc, val) => {
+      const str = val.trim();
+
+      if (str) {
+        acc.push(str);
+      }
+
+      return acc;
+    }, initialValue);
+  }
+
+  return [];
+}
+
+/**
+ * Returns the datum formatted as a number.
+ *
+ * @param datum - CSV data
+ * @returns data formatted as number
+ */
+function formatDatumAsNumber(datum: string): number {
+  if (!datum) {
+    return 0;
+  }
+
+  const value = datum.replace(/,/g, "");
+
+  return Number(value);
+}
+
+/**
+ * Returns the datum formatted as a string.
+ *
+ * @param datum - CSV data
+ * @returns string value
+ */
+function formatDatumAsString(datum: string): string {
+  if (datum) {
+    return datum.trim();
+  }
+
+  return "";
+}
+
+/**
+ * Returns the datum formatted as a boolean.
+ *
+ * @param datum - CSV data
+ * @returns boolean value
+ */
+function formatDatumAsBoolean(datum: string): boolean {
+  if (datum) {
+    return datum.toLowerCase() === "true";
+  }
+
+  return false;
+}
+
+/**
+ * Returns the datum, corrected for type.
+ * i.e. will return a number as Number, instead of a string.
+ *
+ * @param datum - CSV data
+ * @param fieldType - field type
+ * @returns formatted data
+ */
+function parseDatumValue(
+  datum: string,
+  fieldType: string
+): ReturnType | ReturnType[] {
+  /* Format datum as number. */
+  if (fieldType === "number") {
+    return formatDatumAsNumber(datum);
+  }
+
+  /* Format datum as array. */
+  if (fieldType === "array") {
+    return formatDatumAsArray(datum);
+  }
+
+  if (fieldType === "string") {
+    return formatDatumAsString(datum);
+  }
+
+  if (fieldType === "boolean") {
+    return formatDatumAsBoolean(datum);
+  }
+
+  return datum;
+}


### PR DESCRIPTION
Closes #202 

With these changes, to reuse the `getStaticProps` and `getStaticPaths` you need to call:

```
config();

export {
  getStaticPaths,
  getStaticProps,
} from "@clevercanary/data-explorer-ui/lib/server";

``` 

The call to `config()` on the page file is necessary to make the current config available to `data-explorer`. Maybe the change proposed on this [issue](https://github.com/clevercanary/data-browser/issues/826) could remove the need for this call. But I'm not sure, more tests would be needed.