### PR TITLE
fix: use current tab value always (#81)

### DIFF
--- a/packages/data-explorer-ui/src/hooks/useEntityService.ts
+++ b/packages/data-explorer-ui/src/hooks/useEntityService.ts
@@ -1,7 +1,9 @@
 import { EntityConfig } from "../config/entities";
+import { getEntityConfig } from "../config/utils";
 import { createEntityService } from "../entity/service/factory";
 import { EntityService } from "../entity/service/model";
 import { useConfig } from "./useConfig";
+import { useExploreState } from "./useExploreState";
 
 interface FetcherResponse extends EntityService {
   detailStaticLoad: boolean;
@@ -41,6 +43,11 @@ export const getEntityService = (
  * @returns @see FetcherResponse
  */
 export const useEntityService = (): FetcherResponse => {
-  const { entityConfig } = useConfig();
+  const { config } = useConfig();
+  const { exploreState } = useExploreState();
+  const entityConfig = getEntityConfig(
+    config.entities,
+    exploreState.tabValue // always use the current state's tab value.
+  );
   return getEntityService(entityConfig);
 };


### PR DESCRIPTION
Closes #81 

Changes: Always use the entity config from the state (and not from the incoming AzulStaticResponse) to keep the state in sync and the entity list type always matching the entity type.

Tests: I tried this on AnIVL Catalog,  HCA DCP, AnVIL CMG. This removes the double hit of the BE on changing tabs in Azul mode and seems to have no change in catalog mode.

Can you try testing it out locally as well please? @frano-m 

Thanks,
D