### PR TITLE
feat: create download entity curl component (#242)

### DIFF
--- a/packages/data-explorer-ui/src/apis/azul/common/entities.ts
+++ b/packages/data-explorer-ui/src/apis/azul/common/entities.ts
@@ -142,21 +142,6 @@ enum AZUL_TERM_TYPE {
 }
 
 /**
- * Set of export to Terra formats, use when requesting export to Terra location from Azul.
- */
-export enum EXPORT_TO_TERRA_FORMAT {
-  "BDBAG" = "terra.bdbag",
-  "PFB" = "terra.pfb",
-}
-
-/**
- * Set of valid request params accepted by Azul when requesting an export to Terra location.
- */
-export enum EXPORT_TO_TERRA_PARAM {
-  "FORMAT" = "format",
-}
-
-/**
  * Model of fileFormat value included in the response from index/summary API endpoint.
  */
 export interface FileFormatResponse {
@@ -168,6 +153,7 @@ export interface FileFormatResponse {
  * Model of the response to get a download link, using a get-retry approach
  */
 export interface FileLocationResponse {
+  CommandLine: { [key: string]: string };
   Location: string;
   "Retry-After"?: number;
   Status: number;
@@ -181,4 +167,15 @@ export enum LABEL {
   "ERROR" = "Error",
   "NONE" = "None",
   "UNSPECIFIED" = "Unspecified",
+}
+
+/**
+ * Set of possible manifest download formats.
+ */
+export enum MANIFEST_DOWNLOAD_FORMAT {
+  "COMPACT" = "compact",
+  "CURL" = "curl",
+  "FULL" = "full",
+  "TERRA_BDBAG" = "terra.bdbag",
+  "TERRA_PFB" = "terra.pfb",
 }

--- a/packages/data-explorer-ui/src/components/Export/common/entities.ts
+++ b/packages/data-explorer-ui/src/components/Export/common/entities.ts
@@ -1,0 +1,32 @@
+import { MANIFEST_DOWNLOAD_FORMAT } from "../../../apis/azul/common/entities";
+
+/**
+ * Bulk download execution environment.
+ */
+export type BulkDownloadExecutionEnvironment =
+  BULK_DOWNLOAD_EXECUTION_ENVIRONMENT;
+
+/**
+ * Set of supported shells that bulk download curl can be executed on.
+ */
+export enum BULK_DOWNLOAD_EXECUTION_ENVIRONMENT {
+  "BASH" = "bash",
+  "CMD_EXE" = "cmd.exe",
+}
+
+/**
+ * Manifest download format.
+ */
+export type ManifestDownloadFormat = MANIFEST_DOWNLOAD_FORMAT;
+
+/**
+ * Hook returning file manifest request parameters.
+ */
+export type UseExportParams = (
+  manifestFormat: ManifestDownloadFormat
+) => URLSearchParams;
+
+/**
+ * Hook returning file manifest request URL.
+ */
+export type UseExportRequestURL = (requestParams: URLSearchParams) => string;

--- a/packages/data-explorer-ui/src/components/Export/common/utils.ts
+++ b/packages/data-explorer-ui/src/components/Export/common/utils.ts
@@ -1,5 +1,5 @@
 import { EXPORT_TO_TERRA_URL_PFB_FORMAT } from "../../../apis/azul/common/constants";
-import { EXPORT_TO_TERRA_FORMAT } from "../../../apis/azul/common/entities";
+import { MANIFEST_DOWNLOAD_FORMAT } from "../../../apis/azul/common/entities";
 
 /**
  * Build URL to open Azul-generated location in Terra. Export URL requires encoded location and Terra-specific format
@@ -31,7 +31,7 @@ export function buildExportToTerraUrl(
 
   // Build up request params for export link: format if PFB and the encoded location.
   const paramTokens = [];
-  if (format === EXPORT_TO_TERRA_FORMAT.PFB) {
+  if (format === MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB) {
     // Translate Azul PFB format param value to Terra PFB format value. That is, terra.pfb to PFB.
     paramTokens.push(`format=${EXPORT_TO_TERRA_URL_PFB_FORMAT}`);
   }

--- a/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadCurlCommandNotStarted/downloadCurlCommandNotStarted.styles.ts
+++ b/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadCurlCommandNotStarted/downloadCurlCommandNotStarted.styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { ButtonPrimary } from "../../../../../common/Button/button.styles";
+
+export const Button = styled(ButtonPrimary)`
+  text-transform: none;
+`;

--- a/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadCurlCommandNotStarted/downloadCurlCommandNotStarted.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadCurlCommandNotStarted/downloadCurlCommandNotStarted.tsx
@@ -1,0 +1,54 @@
+import React, { ElementType } from "react";
+import { PAPER_PANEL_STYLE } from "../../../../../common/Paper/paper";
+import { FluidPaper } from "../../../../../common/Paper/paper.styles";
+import { Loading } from "../../../../../Loading/loading";
+import {
+  Section,
+  SectionActions,
+  SectionContent,
+  SectionFootnote,
+} from "../../../../export.styles";
+import { ExportToTerraRunFn } from "../../../ExportToTerra/components/ExportToTerraNotStarted/exportToTerraNotStarted";
+import { Button } from "./downloadCurlCommandNotStarted.styles";
+
+export interface DownloadCurlCommandNotStartedProps {
+  DownloadCurlForm: ElementType;
+  DownloadCurlStart: ElementType;
+  isLoading: boolean;
+  run: ExportToTerraRunFn;
+}
+
+export const DownloadCurlCommandNotStarted = ({
+  DownloadCurlForm,
+  DownloadCurlStart,
+  isLoading,
+  run,
+}: DownloadCurlCommandNotStartedProps): JSX.Element => {
+  return (
+    <div>
+      <Loading
+        loading={isLoading}
+        panelStyle={PAPER_PANEL_STYLE.FLUID}
+        text="Your curl command is being prepared..."
+      />
+      <FluidPaper>
+        <Section>
+          <SectionContent>
+            <DownloadCurlStart />
+          </SectionContent>
+          <DownloadCurlForm />
+          <SectionActions>
+            <Button onClick={run}>
+              <span>Request curl Command</span>
+            </Button>
+          </SectionActions>
+          <SectionFootnote>
+            The generated curl command is compatible with the Bash shell on Mac
+            and Linux systems, and the Command shell on Windows systems, and
+            will remain valid for seven days.
+          </SectionFootnote>
+        </Section>
+      </FluidPaper>
+    </div>
+  );
+};

--- a/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadCurlCommandReady/downloadCurlCommandReady.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadCurlCommandReady/downloadCurlCommandReady.tsx
@@ -1,0 +1,25 @@
+import React, { ElementType } from "react";
+import { Code } from "../../../../../common/Code/code";
+import { FluidPaper } from "../../../../../common/Paper/paper.styles";
+import { Section, SectionContent } from "../../../../export.styles";
+
+export interface DownloadCurlCommandReadyProps {
+  curlCommand: string;
+  DownloadCurlSuccess: ElementType;
+}
+
+export const DownloadCurlCommandReady = ({
+  curlCommand,
+  DownloadCurlSuccess,
+}: DownloadCurlCommandReadyProps): JSX.Element => {
+  return (
+    <FluidPaper>
+      <Section>
+        <SectionContent>
+          <DownloadCurlSuccess />
+          <Code code={curlCommand} />
+        </SectionContent>
+      </Section>
+    </FluidPaper>
+  );
+};

--- a/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadEntityCurlCommand/downloadEntityCurlCommand.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/DownloadCurlCommand/components/DownloadEntityCurlCommand/downloadEntityCurlCommand.tsx
@@ -1,0 +1,52 @@
+import React, { ElementType } from "react";
+import { MANIFEST_DOWNLOAD_FORMAT } from "../../../../../../apis/azul/common/entities";
+import {
+  FileLocation,
+  useRequestFileLocation,
+} from "../../../../../../hooks/useRequestFileLocation";
+import {
+  UseExportParams,
+  UseExportRequestURL,
+} from "../../../../common/entities";
+import { DownloadCurlCommandNotStarted } from "../DownloadCurlCommandNotStarted/downloadCurlCommandNotStarted";
+import { DownloadCurlCommandReady } from "../DownloadCurlCommandReady/downloadCurlCommandReady";
+
+export type UseDownloadCurlCommand = (
+  fileLocation?: FileLocation
+) => string | undefined;
+
+interface DownloadEntityCurlCommandProps {
+  DownloadCurlForm: ElementType;
+  DownloadCurlStart: ElementType;
+  DownloadCurlSuccess: ElementType;
+  useDownloadCurlCommand: UseDownloadCurlCommand;
+  useExportParams: UseExportParams;
+  useExportRequestURL: UseExportRequestURL;
+}
+
+export const DownloadEntityCurlCommand = ({
+  DownloadCurlForm,
+  DownloadCurlStart,
+  DownloadCurlSuccess,
+  useDownloadCurlCommand,
+  useExportParams,
+  useExportRequestURL,
+}: DownloadEntityCurlCommandProps): JSX.Element => {
+  const requestParams = useExportParams(MANIFEST_DOWNLOAD_FORMAT.CURL);
+  const requestURL = useExportRequestURL(requestParams);
+  const { data, isLoading, run } = useRequestFileLocation(requestURL);
+  const curlCommand = useDownloadCurlCommand(data);
+  return curlCommand ? (
+    <DownloadCurlCommandReady
+      curlCommand={curlCommand}
+      DownloadCurlSuccess={DownloadCurlSuccess}
+    />
+  ) : (
+    <DownloadCurlCommandNotStarted
+      DownloadCurlForm={DownloadCurlForm}
+      DownloadCurlStart={DownloadCurlStart}
+      isLoading={isLoading}
+      run={run}
+    />
+  );
+};

--- a/packages/data-explorer-ui/src/components/Export/components/ExportEntityToTerra/exportEntityToTerra.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/ExportEntityToTerra/exportEntityToTerra.tsx
@@ -1,13 +1,13 @@
 import React, { ElementType } from "react";
+import { MANIFEST_DOWNLOAD_FORMAT } from "../../../../apis/azul/common/entities";
 import {
   FileLocation,
   useRequestFileLocation,
 } from "../../../../hooks/useRequestFileLocation";
+import { UseExportParams, UseExportRequestURL } from "../../common/entities";
 import { ExportToTerraNotStarted } from "../ExportToTerra/components/ExportToTerraNotStarted/exportToTerraNotStarted";
 import { ExportToTerraReady } from "../ExportToTerra/components/ExportToTerraReady/exportToTerraReady";
 
-export type UseExportParams = () => URLSearchParams;
-export type UseExportRequestURL = (requestParams: URLSearchParams) => string;
 export type UseExportResponseURL = (
   requestParams: URLSearchParams,
   fileLocation?: FileLocation
@@ -30,7 +30,7 @@ export const ExportEntityToTerra = ({
   useExportRequestURL,
   useExportResponseURL,
 }: ExportEntityToTerraProps): JSX.Element => {
-  const requestParams = useExportParams();
+  const requestParams = useExportParams(MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB);
   const requestURL = useExportRequestURL(requestParams);
   const { data, isLoading, run } = useRequestFileLocation(requestURL);
   const exportURL = useExportResponseURL(requestParams, data);

--- a/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/ExportToTerraNotStarted/exportToTerraNotStarted.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/ExportToTerraNotStarted/exportToTerraNotStarted.tsx
@@ -7,7 +7,7 @@ import {
   Section,
   SectionActions,
   SectionContent,
-} from "../../exportToTerra.styles";
+} from "../../../../export.styles";
 
 export type ExportToTerraRunFn = () => void;
 

--- a/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
@@ -7,7 +7,7 @@ import {
   Section,
   SectionActions,
   SectionContent,
-} from "../../exportToTerra.styles";
+} from "../../../../export.styles";
 
 export interface ExportToTerraReadyProps {
   ExportToTerraSuccess: ElementType;

--- a/packages/data-explorer-ui/src/components/Export/export.styles.ts
+++ b/packages/data-explorer-ui/src/components/Export/export.styles.ts
@@ -1,12 +1,13 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { TABLET } from "../../../../theme/common/breakpoints";
-import { ThemeProps } from "../../../../theme/theme";
-import { SectionContent as MDXSectionContent } from "../../../common/MDXMarkdown/components/Section/mdxSection.styles";
+import { textBodySmall4002Lines } from "../../styles/common/mixins/fonts";
+import { TABLET } from "../../theme/common/breakpoints";
+import { ThemeProps } from "../../theme/theme";
+import { SectionContent as MDXSectionContent } from "../common/MDXMarkdown/components/Section/mdxSection.styles";
 import {
   SectionActions as DXSectionActions,
   sectionMarginXsm,
-} from "../../../common/Section/section.styles";
+} from "../common/Section/section.styles";
 
 export const sectionMargin = ({ theme }: ThemeProps) => css`
   ${sectionMarginXsm}
@@ -25,4 +26,10 @@ export const SectionContent = styled(MDXSectionContent)`
 
 export const SectionActions = styled(DXSectionActions)`
   ${sectionMargin}
+`;
+
+export const SectionFootnote = styled.div`
+  ${sectionMargin}
+  ${textBodySmall4002Lines}
+  color: ${({ theme }) => theme.palette.ink.light};
 `;

--- a/packages/data-explorer-ui/src/hooks/useRequestFileLocation.ts
+++ b/packages/data-explorer-ui/src/hooks/useRequestFileLocation.ts
@@ -7,6 +7,7 @@ import { FileLocationResponse } from "../apis/azul/common/entities";
 import { useAsync } from "./useAsync";
 
 export interface FileLocation {
+  commandLine?: { [key: string]: string };
   location: string;
   retryAfter?: number;
   status: number;
@@ -32,6 +33,7 @@ export const getFileLocation = async (url: string): Promise<FileLocation> => {
   const res = await fetch(url);
   const jsonRes: FileLocationResponse = await res.json();
   return {
+    commandLine: jsonRes.CommandLine,
     location: jsonRes.Location,
     retryAfter: jsonRes["Retry-After"],
     status: jsonRes.Status,

--- a/packages/data-explorer-ui/src/providers/detailState.tsx
+++ b/packages/data-explorer-ui/src/providers/detailState.tsx
@@ -1,11 +1,17 @@
 import React, { createContext, ReactNode, useState } from "react";
 import { Filters } from "../common/entities";
+import { BulkDownloadExecutionEnvironment } from "../components/Export/common/entities";
 
-export type UpdateExportFilters = (filters: Filters) => void;
+export type UpdateExecutionEnvironmentFn = (
+  environment: BulkDownloadExecutionEnvironment
+) => void;
+export type UpdateExportFiltersFn = (filters: Filters) => void;
 
 export type DetailStateContextProps = {
+  executionEnvironment?: BulkDownloadExecutionEnvironment;
   exportFilters: Filters;
-  updateExportFilters: UpdateExportFilters;
+  updateExecutionEnvironment: UpdateExecutionEnvironmentFn;
+  updateExportFilters: UpdateExportFiltersFn;
 };
 
 export interface DetailStateProps {
@@ -13,7 +19,10 @@ export interface DetailStateProps {
 }
 
 export const DetailStateContext = createContext<DetailStateContextProps>({
+  executionEnvironment: undefined,
   exportFilters: [],
+  // eslint-disable-next-line @typescript-eslint/no-empty-function -- allow dummy function for default state.
+  updateExecutionEnvironment: () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function -- allow dummy function for default state.
   updateExportFilters: () => {},
 });
@@ -21,7 +30,16 @@ export const DetailStateContext = createContext<DetailStateContextProps>({
 export function DetailStateProvider({
   children,
 }: DetailStateProps): JSX.Element {
+  const [executionEnvironment, setExecutionEnvironment] =
+    useState<BulkDownloadExecutionEnvironment>();
   const [exportFilters, setExportFilters] = useState<Filters>([]);
+
+  // Updates bulk download execution environment.
+  const updateExecutionEnvironment = (
+    environment: BulkDownloadExecutionEnvironment
+  ): void => {
+    setExecutionEnvironment(environment);
+  };
 
   // Updates export filters.
   const updateExportFilters = (filters: Filters): void => {
@@ -31,7 +49,9 @@ export function DetailStateProvider({
   return (
     <DetailStateContext.Provider
       value={{
+        executionEnvironment,
         exportFilters,
+        updateExecutionEnvironment,
         updateExportFilters,
       }}
     >

--- a/packages/data-explorer-ui/src/views/ExportToTerraView/mainColumn.tsx
+++ b/packages/data-explorer-ui/src/views/ExportToTerraView/mainColumn.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import {
   AZUL_PARAM,
-  EXPORT_TO_TERRA_FORMAT,
-  EXPORT_TO_TERRA_PARAM,
+  MANIFEST_DOWNLOAD_FORMAT,
 } from "../../apis/azul/common/entities";
 import { transformFilters } from "../../apis/azul/common/filterTransformer";
 import { ExportToTerra } from "../../components/Export/components/ExportToTerra/exportToTerra";
@@ -30,7 +29,7 @@ export const MainColumn = (): JSX.Element => {
   // Build request params.
   const requestParams: URLSearchParams = new URLSearchParams({
     [AZUL_PARAM.CATALOG]: catalog,
-    [EXPORT_TO_TERRA_PARAM.FORMAT]: EXPORT_TO_TERRA_FORMAT.PFB,
+    format: MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB,
   });
 
   // Add filters to request params, if any.


### PR DESCRIPTION
Closes #242.
Closes https://github.com/DataBiosphere/findable-ui/issues/12.

### Note
- Breaking change for use of `ExportEntityToTerra`.