### PR TITLE
feat: add query params to url (#223)

### DIFF
--- a/packages/data-explorer-ui/src/components/Table/table.tsx
+++ b/packages/data-explorer-ui/src/components/Table/table.tsx
@@ -221,7 +221,9 @@ TableProps<T>): JSX.Element => {
     }
   }, [filterState, isRelatedView, listStaticLoad, tableInstance]);
 
-  // Builds categoryViews using react table `getFacetedUniqueValues`, for statically loaded api only, with update of columnFilters.
+  /**
+   * Static List Mode - Process Explore Response
+   */
   useEffect(() => {
     if (!isRelatedView && listStaticLoad) {
       exploreDispatch({
@@ -247,7 +249,7 @@ TableProps<T>): JSX.Element => {
     isRelatedView,
     listItems,
     listStaticLoad,
-    tableInstance.getFilteredRowModel().rows
+    tableInstance.getFilteredRowModel().rows,
   ]);
 
   // Unmount - reset entity view to "exact".

--- a/packages/data-explorer-ui/src/components/Table/table.tsx
+++ b/packages/data-explorer-ui/src/components/Table/table.tsx
@@ -224,6 +224,7 @@ TableProps<T>): JSX.Element => {
   /**
    * Static List Mode - Process Explore Response
    */
+  const tableRows = tableInstance.getFilteredRowModel().rows;
   useEffect(() => {
     if (!isRelatedView && listStaticLoad) {
       exploreDispatch({
@@ -232,10 +233,10 @@ TableProps<T>): JSX.Element => {
           loading: false,
           paginationResponse: {
             nextIndex: null,
-            pageSize: tableInstance.getFilteredRowModel().rows.length,
+            pageSize: tableRows.length,
             pages: 1,
             previousIndex: null,
-            rows: tableInstance.getFilteredRowModel().rows.length,
+            rows: tableRows.length,
           },
           selectCategories: buildCategoryViews(allColumns, columnFilters),
         },
@@ -249,7 +250,7 @@ TableProps<T>): JSX.Element => {
     isRelatedView,
     listItems,
     listStaticLoad,
-    tableInstance.getFilteredRowModel().rows,
+    tableRows,
   ]);
 
   // Unmount - reset entity view to "exact".

--- a/packages/data-explorer-ui/src/components/Table/table.tsx
+++ b/packages/data-explorer-ui/src/components/Table/table.tsx
@@ -247,7 +247,7 @@ TableProps<T>): JSX.Element => {
     isRelatedView,
     listItems,
     listStaticLoad,
-    tableInstance,
+    tableInstance.getFilteredRowModel().rows
   ]);
 
   // Unmount - reset entity view to "exact".

--- a/packages/data-explorer-ui/src/components/Table/table.tsx
+++ b/packages/data-explorer-ui/src/components/Table/table.tsx
@@ -224,7 +224,6 @@ TableProps<T>): JSX.Element => {
   /**
    * Static List Mode - Process Explore Response
    */
-  const tableRows = tableInstance.getFilteredRowModel().rows;
   useEffect(() => {
     if (!isRelatedView && listStaticLoad) {
       exploreDispatch({
@@ -233,10 +232,10 @@ TableProps<T>): JSX.Element => {
           loading: false,
           paginationResponse: {
             nextIndex: null,
-            pageSize: tableRows.length,
+            pageSize: results.length,
             pages: 1,
             previousIndex: null,
-            rows: tableRows.length,
+            rows: results.length,
           },
           selectCategories: buildCategoryViews(allColumns, columnFilters),
         },
@@ -250,7 +249,7 @@ TableProps<T>): JSX.Element => {
     isRelatedView,
     listItems,
     listStaticLoad,
-    tableRows,
+    results,
   ]);
 
   // Unmount - reset entity view to "exact".

--- a/packages/data-explorer-ui/src/hooks/useEntityList.ts
+++ b/packages/data-explorer-ui/src/hooks/useEntityList.ts
@@ -34,13 +34,16 @@ export const useEntityList = (
   const { termFacets } = data || {};
   const { updateFilterQueryString } = useURLFilterParams();
 
+  /**
+   * Update the filter query string when the filter state changes.
+   */
   useEffect(() => {
     updateFilterQueryString(filterState);
   }, [filterState, updateFilterQueryString]);
 
   /**
-   * Hook for fetching entities matching the current query and authentication state.
-   * Only runs if one of its deps changes. Skipped if staticLoaded entity
+   * Fetch Entities from the API when the filter state changes.
+   * Server-side filtering
    */
   useEffect(() => {
     if (!listStaticLoad) {
@@ -78,7 +81,11 @@ export const useEntityList = (
     token,
   ]);
 
-  // Builds categoryViews with an update of term facets.
+  /**
+   * Process Explore Response when data changes.
+   * TODO filre this directly when the API respnse returns
+   * Server-side filtering
+   */
   useEffect(() => {
     if (!listStaticLoad && termFacets) {
       exploreDispatch({
@@ -103,6 +110,7 @@ export const useEntityList = (
   ]);
 
   /**
+   * Process Static Explore Response
    * For static loaded data (client side filtering) update the listItems with
    * the static response if it exists when the page loads
    **/

--- a/packages/data-explorer-ui/src/hooks/useLocation.ts
+++ b/packages/data-explorer-ui/src/hooks/useLocation.ts
@@ -1,0 +1,31 @@
+import { isSSR } from "../utils/ssr";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The result will be a object containing anything set on the url parameters
+type Search = any;
+interface Result {
+  href: string;
+  pathname: string;
+  search: Search;
+}
+
+/**
+ * Hook used to get the url properties from the location object
+ * Most of the times you can get the same result with useRouter(). This hook has a single use case:
+ *  - When you need to get the url properties ready on the first render, before ReactDOM.hydrate
+ * @returns an object containing url's pathname and search params
+ */
+export const useLocation = (): Result | null => {
+  if (isSSR()) {
+    return null;
+  }
+
+  const { href, pathname, search: locationSearch } = window.location;
+  const search = Object.fromEntries(
+    new URLSearchParams(locationSearch).entries()
+  );
+  return {
+    href,
+    pathname,
+    search,
+  };
+};

--- a/packages/data-explorer-ui/src/hooks/useLocation.ts
+++ b/packages/data-explorer-ui/src/hooks/useLocation.ts
@@ -10,7 +10,7 @@ interface Result {
 
 /**
  * Hook used to get the url properties from the location object
- * Most of the times you can get the same result with useRouter(). This hook has a single use case:
+ * Most of the time you can get the same result with useRouter(). This hook has a single use case:
  *  - When you need to get the url properties ready on the first render, before ReactDOM.hydrate
  * @returns an object containing url's pathname and search params
  */

--- a/packages/data-explorer-ui/src/hooks/useLocation.ts
+++ b/packages/data-explorer-ui/src/hooks/useLocation.ts
@@ -1,11 +1,9 @@
 import { isSSR } from "../utils/ssr";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The result will be a object containing anything set on the url parameters
-type Search = any;
 interface Result {
   href: string;
   pathname: string;
-  search: Search;
+  search: URLSearchParams;
 }
 
 /**
@@ -18,14 +16,10 @@ export const useLocation = (): Result | null => {
   if (isSSR()) {
     return null;
   }
-
-  const { href, pathname, search: locationSearch } = window.location;
-  const search = Object.fromEntries(
-    new URLSearchParams(locationSearch).entries()
-  );
+  const { href, pathname, search } = window.location;
   return {
     href,
     pathname,
-    search,
+    search: new URLSearchParams(search),
   };
 };

--- a/packages/data-explorer-ui/src/hooks/useURLFilterParams.ts
+++ b/packages/data-explorer-ui/src/hooks/useURLFilterParams.ts
@@ -15,18 +15,17 @@ interface UseURLFilterParamsResult {
  */
 export const useURLFilterParams = (): UseURLFilterParamsResult => {
   const { basePath, push } = useRouter();
-  const location = useLocation();
-  const filterParam = location?.search?.filter ?? "[]";
-  const decodedFilterParam = decodeURIComponent(filterParam);
+  const { href, pathname, search } = useLocation() || {};
+  const filterParam = search?.get("filter") ?? "[]";
 
   const updateFilterQueryString = useCallback(
     (filterState: SelectedFilter[]) => {
-      if (decodedFilterParam !== JSON.stringify(filterState)) {
+      if (filterParam !== JSON.stringify(filterState)) {
         const filter =
           filterState.length > 0 ? { filter: JSON.stringify(filterState) } : {};
         push(
           {
-            pathname: location?.pathname.replace(basePath, ""),
+            pathname: pathname?.replace(basePath, ""),
             query: { ...filter },
           },
           undefined,
@@ -37,11 +36,11 @@ export const useURLFilterParams = (): UseURLFilterParamsResult => {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- push method isn't memoized and shouldn't be added as deps https://github.com/vercel/next.js/issues/18127
-    [location?.href, decodedFilterParam]
+    [filterParam, href]
   );
 
   return {
-    decodedFilterParam,
+    decodedFilterParam: filterParam,
     updateFilterQueryString,
   };
 };

--- a/packages/data-explorer-ui/src/hooks/useURLFilterParams.ts
+++ b/packages/data-explorer-ui/src/hooks/useURLFilterParams.ts
@@ -1,0 +1,47 @@
+import { SelectedFilter } from "common/entities";
+import { useRouter } from "next/router";
+import { useCallback } from "react";
+import { useLocation } from "./useLocation";
+
+interface UseURLFilterParamsResult {
+  decodedFilterParam: string;
+  updateFilterQueryString: (filterState: SelectedFilter[]) => void;
+}
+
+/**
+ * useURLFilterParams hook is used to keep track of the url search params, and update them,
+ * if needed
+ * @returns an object containing a update function and the current filter
+ */
+export const useURLFilterParams = (): UseURLFilterParamsResult => {
+  const { basePath, push } = useRouter();
+  const location = useLocation();
+  const filterParam = location?.search?.filter ?? "[]";
+  const decodedFilterParam = decodeURIComponent(filterParam);
+
+  const updateFilterQueryString = useCallback(
+    (filterState: SelectedFilter[]) => {
+      if (decodedFilterParam !== JSON.stringify(filterState)) {
+        const filter =
+          filterState.length > 0 ? { filter: JSON.stringify(filterState) } : {};
+        push(
+          {
+            pathname: location?.pathname.replace(basePath, ""),
+            query: { ...filter },
+          },
+          undefined,
+          {
+            shallow: true,
+          }
+        );
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- push method isn't memoized and shouldn't be added as deps https://github.com/vercel/next.js/issues/18127
+    [location?.href, decodedFilterParam]
+  );
+
+  return {
+    decodedFilterParam,
+    updateFilterQueryString,
+  };
+};

--- a/packages/data-explorer-ui/src/providers/exploreState.tsx
+++ b/packages/data-explorer-ui/src/providers/exploreState.tsx
@@ -191,12 +191,19 @@ export function ExploreStateProvider({
 }): JSX.Element {
   const { config, defaultEntityListType, entityConfig } = useConfig();
   const { decodedFilterParam } = useURLFilterParams();
+  // Define filter state, from URL "filter" parameter, if present and valid.
+  let filterState: SelectedFilter[] = [];
+  try {
+    filterState = JSON.parse(decodedFilterParam);
+  } catch {
+    // do nothing
+  }
   const [exploreState, exploreDispatch] = useReducer(
     (s: ExploreState, a: ExploreAction) =>
       exploreReducer(s, a, { config, entityConfig }),
     {
       categoryViews: [],
-      filterState: JSON.parse(decodedFilterParam),
+      filterState,
       isRelatedView: false,
       listItems: [],
       listStaticLoad: entityConfig.staticLoad ?? false,

--- a/packages/data-explorer-ui/src/providers/exploreState.tsx
+++ b/packages/data-explorer-ui/src/providers/exploreState.tsx
@@ -1,5 +1,11 @@
 import { ColumnSort } from "@tanstack/react-table";
-import React, { createContext, Dispatch, ReactNode, useMemo, useReducer } from "react";
+import React, {
+  createContext,
+  Dispatch,
+  ReactNode,
+  useMemo,
+  useReducer,
+} from "react";
 import { AzulSearchIndex } from "../apis/azul/common/entities";
 import {
   CategoryKey,
@@ -206,8 +212,8 @@ export function ExploreStateProvider({
 
   // does this help? https://hswolff.com/blog/how-to-usecontext-with-usereducer/
   const exploreContextValue = useMemo(() => {
-    return { exploreState, exploreDispatch };
-  }, [exploreState, exploreDispatch]);
+    return { exploreDispatch, exploreState };
+  }, [exploreDispatch, exploreState]);
 
   return (
     <ExploreStateContext.Provider value={exploreContextValue}>
@@ -267,7 +273,6 @@ type ProcessExploreStaticResponseAction = {
   payload: ExploreStaticResponse;
   type: ExploreActionKind.ProcessExploreStaticResponse;
 };
-
 
 /**
  * Process related response action.
@@ -380,10 +385,10 @@ function exploreReducer(
         },
       };
     }
-     /**
+    /**
      * Process explore response
      **/
-     case ExploreActionKind.ProcessExploreStaticResponse: {
+    case ExploreActionKind.ProcessExploreStaticResponse: {
       let listItems: ListItems = [];
       if (!payload.loading) {
         listItems = payload.listItems;

--- a/packages/data-explorer-ui/src/views/ExploreView/exploreView.tsx
+++ b/packages/data-explorer-ui/src/views/ExploreView/exploreView.tsx
@@ -151,7 +151,6 @@ function renderEntities(
   if (entityListType !== tabValue) {
     // required currently for static load site as the pre-rendered page
     // loads with the previous tabs data on the first render after switching tabs. (or similar)
-    //console.log("Entity list type != tab value", entityListType, tabValue);
     return <></>; // TODO(Fran) review loading and return.
   }
 

--- a/packages/data-explorer-ui/src/views/ExploreView/exploreView.tsx
+++ b/packages/data-explorer-ui/src/views/ExploreView/exploreView.tsx
@@ -87,7 +87,9 @@ export const ExploreView = (props: ExploreViewProps): JSX.Element => {
     push(`/${tabValue}`);
   };
 
-  // Selects entity type with update to entity list type.
+  /**
+   * Dispach a SelectdEntityType action when entityListType changes.
+   */
   useEffect(() => {
     if (entityListType) {
       exploreDispatch({


### PR DESCRIPTION
I have tested this, but please test thoroughly on both client and server-side filtering.

How this works basically is:
#### On selecting a filter

1. The user selects a filter
2. The onFilterChange is fired, dispatching the UpdateFilter action
3. The table filters
4. Independtly a new hook updates the queryString from the filterState using [shallow](https://nextjs.org/docs/pages/building-your-application/routing/linking-and-navigating#shallow-routing)=true on push to prevent reloading the page.

#### On page load
When a new page is hit:

1. useURLFilterParams is called in exploreState.tsx to set the initial state of the filter from the URL params
