### PR TITLE
feat: use virtualized list for filter dropdowns (#248)

### DIFF
--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -56,6 +56,7 @@
         "react-dom": "17.0.2",
         "react-gtm-module": "2.0.11",
         "react-idle-timer": "^5.6.2",
+        "react-virtuoso": "^4.3.11",
         "uuid": "8.3.2"
       }
     },
@@ -19753,6 +19754,19 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtuoso": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.4.0.tgz",
+      "integrity": "sha512-7hVk43DN9Sx6czpclTpPnB2uzDmCaioSoTSN8lRv4mMF7UL5jmfc58UpjRrGoJavzVn1VBjHLLj6RHBLsS+N5Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18",
+        "react-dom": ">=16 || >=17 || >= 18"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -37059,6 +37073,13 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-virtuoso": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.4.0.tgz",
+      "integrity": "sha512-7hVk43DN9Sx6czpclTpPnB2uzDmCaioSoTSN8lRv4mMF7UL5jmfc58UpjRrGoJavzVn1VBjHLLj6RHBLsS+N5Q==",
+      "peer": true,
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/packages/data-explorer-ui/package.json
+++ b/packages/data-explorer-ui/package.json
@@ -68,6 +68,7 @@
     "react-dom": "17.0.2",
     "react-gtm-module": "2.0.11",
     "react-idle-timer": "^5.6.2",
+    "react-virtuoso": "^4.3.11",
     "uuid": "8.3.2"
   }
 }

--- a/packages/data-explorer-ui/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
@@ -1,9 +1,10 @@
 import styled from "@emotion/styled";
+import { Virtuoso } from "react-virtuoso";
 
 const LIST_ITEM_HEIGHT = 40;
 const LIST_PADDING_TOP = 8;
 export const MAX_DISPLAYABLE_LIST_ITEMS = 8;
-export const MAX_LIST_HEIGHT_PX =
+const MAX_LIST_HEIGHT_PX =
   (MAX_DISPLAYABLE_LIST_ITEMS + 0.5) * LIST_ITEM_HEIGHT + LIST_PADDING_TOP;
 
 interface Props {
@@ -33,6 +34,14 @@ export const FilterView = styled.div<Props>`
     > span {
       min-width: 0; /* required; flexbox child min-width property is "auto" by default making overflow-wrap ineffectual */
     }
+  }
+`;
+
+export const VirtuosoList = styled(Virtuoso)`
+  max-height: ${MAX_LIST_HEIGHT_PX}px;
+
+  > div {
+    position: relative !important;
   }
 `;
 

--- a/packages/data-explorer-ui/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 const LIST_ITEM_HEIGHT = 40;
 const LIST_PADDING_TOP = 8;
 export const MAX_DISPLAYABLE_LIST_ITEMS = 8;
-const MAX_LIST_HEIGHT_PX =
+export const MAX_LIST_HEIGHT_PX =
   (MAX_DISPLAYABLE_LIST_ITEMS + 0.5) * LIST_ITEM_HEIGHT + LIST_PADDING_TOP;
 
 interface Props {
@@ -15,10 +15,7 @@ export const FilterView = styled.div<Props>`
 
   // List
   .MuiList-root {
-    max-height: ${MAX_LIST_HEIGHT_PX}px;
-    overflow: auto;
     overflow-wrap: break-word;
-    padding: 8px 0;
   }
 
   // List item
@@ -37,4 +34,8 @@ export const FilterView = styled.div<Props>`
       min-width: 0; /* required; flexbox child min-width property is "auto" by default making overflow-wrap ineffectual */
     }
   }
+`;
+
+export const ListPadding = styled.div`
+  height: 8px;
 `;

--- a/packages/data-explorer-ui/src/components/Filter/components/FilterMenu/filterMenu.tsx
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterMenu/filterMenu.tsx
@@ -6,7 +6,6 @@ import {
   Typography,
 } from "@mui/material";
 import React, { useState } from "react";
-import { Virtuoso } from "react-virtuoso";
 import {
   CategoryKey,
   SelectCategoryValueView,
@@ -20,7 +19,7 @@ import {
   FilterView,
   ListPadding,
   MAX_DISPLAYABLE_LIST_ITEMS,
-  MAX_LIST_HEIGHT_PX,
+  VirtuosoList,
 } from "./filterMenu.styles";
 
 export interface FilterMenuProps {
@@ -43,7 +42,6 @@ export const FilterMenu = ({
   values,
 }: FilterMenuProps): JSX.Element => {
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const [listHeight, setListHeight] = useState(MAX_LIST_HEIGHT_PX);
   const isSearchable = values.length > MAX_DISPLAYABLE_LIST_ITEMS;
   const filteredValues = isSearchable
     ? applyMenuFilter(values, searchTerm)
@@ -80,17 +78,11 @@ export const FilterMenu = ({
         />
       )}
       {filteredValues.length > 0 ? (
-        <Virtuoso
-          style={{ height: listHeight }}
+        <VirtuosoList
           components={muiComponents}
           totalCount={filteredValues.length + 2} // add 2 for padding items
           defaultItemHeight={40}
           increaseViewportBy={200}
-          totalListHeightChanged={(height): void =>
-            setListHeight(
-              height < MAX_LIST_HEIGHT_PX ? height : MAX_LIST_HEIGHT_PX
-            )
-          }
           computeItemKey={(index): string =>
             getListEdge(index) || getFilteredValue(index).key
           }


### PR DESCRIPTION
Some things to note:
- I was able to get Virtuoso to render enough items by setting the `increaseViewportBy` attribute; I don't have much reasoning behind the value 200 though -- I just made a guess and it seems to work.
- CSS padding at the top and bottom of the list doesn't have an effect, so I've added list items to act as padding instead.
- Giving the list container a maximum height and shrinking it to fit the number of items is tricky. I tried using the `totalListHeightChanged` callback, but in certain cases it gave inaccurate height values, which made the list smaller than it should be until it was scrolled and the height updated. 775f22cc75643348a99f752de181f94a154cb640 changes to a fully CSS-based solution, which seems to work better in some ways, but involves messing with elements created by the Virtuoso component (based just on my own experimentation to see what works), and has an issue where, when the list is opened, it doesn't adjust its position to stay in the viewport.