### PR TITLE
fix: use inline element for highlight and adjust horizontal padding (#296)

### DIFF
--- a/packages/data-explorer-ui/src/components/Filter/components/SearchAllFilters/searchAllFilters.styles.ts
+++ b/packages/data-explorer-ui/src/components/Filter/components/SearchAllFilters/searchAllFilters.styles.ts
@@ -1,6 +1,12 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Autocomplete, Divider, Paper } from "@mui/material";
 import { FilterOption } from "./searchAllFilters";
+
+interface MatchHighlightProps {
+  leftOpen: boolean;
+  rightOpen: boolean;
+}
 
 export const SearchAllFilters = styled(
   Autocomplete<FilterOption, false, false, true>
@@ -21,9 +27,22 @@ export const GroupDivider = styled(Divider)`
   margin: 8px 0;
 `;
 
-export const MatchHighlight = styled.mark`
+export const MatchHighlight = styled.mark<MatchHighlightProps>`
   background: ${({ theme }) => theme.palette.warning.light};
-  display: inline-block;
-  padding: 0 2px;
   color: inherit;
+  padding: 2px 0;
+
+  ${({ leftOpen }) =>
+    leftOpen &&
+    css`
+      padding-left: 2px;
+      margin-left: -2px;
+    `}
+
+  ${({ rightOpen }) =>
+    rightOpen &&
+    css`
+      padding-right: 2px;
+      margin-right: -2px;
+    `}
 `;

--- a/packages/data-explorer-ui/src/components/Filter/components/SearchAllFilters/searchAllFilters.tsx
+++ b/packages/data-explorer-ui/src/components/Filter/components/SearchAllFilters/searchAllFilters.tsx
@@ -194,12 +194,25 @@ function markSearchTerm(
 ): React.ReactNode {
   let prevIndex = 0;
   return [
-    Array.from(label.matchAll(searchTermRegExp), (match, index) => {
+    Array.from(label.matchAll(searchTermRegExp), (match, itemIndex) => {
+      const [matchText] = match;
+      const matchIndex = match.index as number; // type assertion to get around a TypeScript bug: https://github.com/microsoft/TypeScript/issues/36788
+      const endIndex = matchIndex + matchText.length;
+      const leftChar = label[matchIndex - 1];
+      const rightChar = label[endIndex];
+      const leftOpen = !leftChar || /\s/.test(leftChar);
+      const rightOpen = !rightChar || /\s/.test(rightChar);
       const items = [
-        label.substring(prevIndex, match.index),
-        <MatchHighlight key={index}>{match[0]}</MatchHighlight>,
+        label.substring(prevIndex, matchIndex),
+        <MatchHighlight
+          key={itemIndex}
+          leftOpen={leftOpen}
+          rightOpen={rightOpen}
+        >
+          {matchText}
+        </MatchHighlight>,
       ];
-      prevIndex = (match.index as number) + match[0].length; // type conversion to get around a TypeScript bug: https://github.com/microsoft/TypeScript/issues/36788
+      prevIndex = endIndex;
       return items;
     }),
     label.substring(prevIndex),


### PR DESCRIPTION
In addition to resolving the issues with wrapping and spaces, I've also made it so that the highlight only has horizontal padding when the edge is next to whitespace or the edge of the text, in order to better match the mock (where e.g. the highlighted "liver" in "Celliver Biotechnology Inc" appears to have right padding but not left padding)