### PR TITLE
fix: add rel=noopener noreferrer to the "export to terra" link (#345)

### DIFF
--- a/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
@@ -19,7 +19,7 @@ export const ExportToTerraReady = ({
   exportURL,
 }: ExportToTerraReadyProps): JSX.Element => {
   const onOpenTerra = (): void => {
-    window.open(exportURL, ANCHOR_TARGET.BLANK, "noopener");
+    window.open(exportURL, ANCHOR_TARGET.BLANK, "noopener noreferrer");
   };
   return (
     <FluidPaper>


### PR DESCRIPTION
Closes #345.