### PR TITLE
feat: virtualize entity lists

### DIFF
--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -57,6 +57,7 @@
         "react-dom": "17.0.2",
         "react-gtm-module": "2.0.11",
         "react-idle-timer": "^5.6.2",
+        "react-virtual": "^2.10.4",
         "react-window": "1.8.9",
         "uuid": "8.3.2"
       }
@@ -4224,6 +4225,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@reach/observe-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==",
+      "peer": true
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.2.0",
@@ -19814,6 +19821,21 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtual": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
+      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
+      "funding": [
+        "https://github.com/sponsors/tannerlinsley"
+      ],
+      "peer": true,
+      "dependencies": {
+        "@reach/observe-rect": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.3 || ^17.0.0"
+      }
+    },
     "node_modules/react-window": {
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.9.tgz",
@@ -25654,6 +25676,12 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
+    },
+    "@reach/observe-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==",
       "peer": true
     },
     "@rushstack/eslint-patch": {
@@ -37209,6 +37237,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtual": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
+      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
+      "peer": true,
+      "requires": {
+        "@reach/observe-rect": "^1.1.0"
       }
     },
     "react-window": {

--- a/packages/data-explorer-ui/package-lock.json
+++ b/packages/data-explorer-ui/package-lock.json
@@ -49,6 +49,7 @@
         "@mui/icons-material": "5.14.1",
         "@mui/material": "5.14.1",
         "@tanstack/react-table": "8.5.11",
+        "@tanstack/react-virtual": "^3.0.0-beta.59",
         "axios": "1.3.5",
         "copy-to-clipboard": "3.3.1",
         "isomorphic-dompurify": "0.24.0",
@@ -57,7 +58,6 @@
         "react-dom": "17.0.2",
         "react-gtm-module": "2.0.11",
         "react-idle-timer": "^5.6.2",
-        "react-virtual": "^2.10.4",
         "react-window": "1.8.9",
         "uuid": "8.3.2"
       }
@@ -4226,12 +4226,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@reach/observe-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
-      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==",
-      "peer": true
-    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
@@ -7504,6 +7498,22 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.59.tgz",
+      "integrity": "sha512-6t0813V/yiY/rWSwW5TEHMn97LJPDYv6aW75KVJnt5o14Y3ghqFnbX3nJ3icQXfsqYjPoIgXH4TAr8v/w0cZqA==",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/virtual-core": "3.0.0-beta.59"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.5.11",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.5.11.tgz",
@@ -7512,6 +7522,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.59.tgz",
+      "integrity": "sha512-Z6V6VXk8D4jaRHx8klvL6jUOYWIkWUODTyVQJSfnxAVu8vnuz99FgBXhY/mLZ5qjEX5OPESZZVKRTKqGpMEQKw==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -19821,21 +19841,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/react-virtual": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
-      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
-      "funding": [
-        "https://github.com/sponsors/tannerlinsley"
-      ],
-      "peer": true,
-      "dependencies": {
-        "@reach/observe-rect": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.3 || ^17.0.0"
-      }
-    },
     "node_modules/react-window": {
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.9.tgz",
@@ -25678,12 +25683,6 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "peer": true
     },
-    "@reach/observe-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
-      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==",
-      "peer": true
-    },
     "@rushstack/eslint-patch": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
@@ -27991,10 +27990,25 @@
         "@tanstack/table-core": "8.5.11"
       }
     },
+    "@tanstack/react-virtual": {
+      "version": "3.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.59.tgz",
+      "integrity": "sha512-6t0813V/yiY/rWSwW5TEHMn97LJPDYv6aW75KVJnt5o14Y3ghqFnbX3nJ3icQXfsqYjPoIgXH4TAr8v/w0cZqA==",
+      "peer": true,
+      "requires": {
+        "@tanstack/virtual-core": "3.0.0-beta.59"
+      }
+    },
     "@tanstack/table-core": {
       "version": "8.5.11",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.5.11.tgz",
       "integrity": "sha512-ZN61ockLaIAiiPbZfMKT2S03nbWx28OHg/nAiDnNfmN4QmAMcdwVajPn2QQwnNVGAr4jS4nbhbYzCcjq8livXQ==",
+      "peer": true
+    },
+    "@tanstack/virtual-core": {
+      "version": "3.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.59.tgz",
+      "integrity": "sha512-Z6V6VXk8D4jaRHx8klvL6jUOYWIkWUODTyVQJSfnxAVu8vnuz99FgBXhY/mLZ5qjEX5OPESZZVKRTKqGpMEQKw==",
       "peer": true
     },
     "@testing-library/dom": {
@@ -37237,15 +37251,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-virtual": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
-      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
-      "peer": true,
-      "requires": {
-        "@reach/observe-rect": "^1.1.0"
       }
     },
     "react-window": {

--- a/packages/data-explorer-ui/package.json
+++ b/packages/data-explorer-ui/package.json
@@ -69,7 +69,7 @@
     "react-dom": "17.0.2",
     "react-gtm-module": "2.0.11",
     "react-idle-timer": "^5.6.2",
-    "react-virtual": "^2.10.4",
+    "@tanstack/react-virtual": "^3.0.0-beta.59",
     "react-window": "1.8.9",
     "uuid": "8.3.2"
   }

--- a/packages/data-explorer-ui/package.json
+++ b/packages/data-explorer-ui/package.json
@@ -69,6 +69,7 @@
     "react-dom": "17.0.2",
     "react-gtm-module": "2.0.11",
     "react-idle-timer": "^5.6.2",
+    "react-virtual": "^2.10.4",
     "react-window": "1.8.9",
     "uuid": "8.3.2"
   }

--- a/packages/data-explorer-ui/src/components/Table/table.tsx
+++ b/packages/data-explorer-ui/src/components/Table/table.tsx
@@ -180,7 +180,8 @@ TableProps<T>): JSX.Element => {
   const scrollTop = useScroll();
   const isLastPage = currentPage === pages;
   const editColumnOptions = getEditColumnOptions(tableInstance);
-  const gridTemplateColumns = getGridTemplateColumns(getVisibleFlatColumns());
+  const visibleColumns = getVisibleFlatColumns();
+  const gridTemplateColumns = getGridTemplateColumns(visibleColumns);
   const estimateSize = useCallback(() => 100, []);
   const virtualizer = useWindowVirtualizer({
     count: results.length,
@@ -351,13 +352,7 @@ TableProps<T>): JSX.Element => {
           </Alert>
         )}
         <TableContainer>
-          <GridTable
-            gridTemplateColumns={gridTemplateColumns}
-            style={{
-              paddingBottom: `${virtualizerPaddingBottom}px`,
-              paddingTop: `${virtualizerPaddingTop}px`,
-            }}
-          >
+          <GridTable gridTemplateColumns={gridTemplateColumns}>
             {getHeaderGroups().map((headerGroup) => (
               <TableHead key={headerGroup.id}>
                 <TableRow>
@@ -377,6 +372,16 @@ TableProps<T>): JSX.Element => {
               </TableHead>
             ))}
             <TableBody>
+              {virtualizerPaddingTop > 0 && (
+                <tr>
+                  <td
+                    style={{
+                      gridColumn: `span ${visibleColumns.length}`,
+                      height: `${virtualizerPaddingTop}px`,
+                    }}
+                  ></td>
+                </tr>
+              )}
               {virtualItems.map((virtualRow) => {
                 const row = results[virtualRow.index];
                 return (
@@ -398,6 +403,16 @@ TableProps<T>): JSX.Element => {
                   </TableRow>
                 );
               })}
+              {virtualizerPaddingBottom > 0 && (
+                <tr>
+                  <td
+                    style={{
+                      gridColumn: `span ${visibleColumns.length}`,
+                      height: `${virtualizerPaddingBottom}px`,
+                    }}
+                  ></td>
+                </tr>
+              )}
             </TableBody>
           </GridTable>
         </TableContainer>

--- a/packages/data-explorer-ui/src/components/Table/table.tsx
+++ b/packages/data-explorer-ui/src/components/Table/table.tsx
@@ -181,17 +181,19 @@ TableProps<T>): JSX.Element => {
   const isLastPage = currentPage === pages;
   const editColumnOptions = getEditColumnOptions(tableInstance);
   const gridTemplateColumns = getGridTemplateColumns(getVisibleFlatColumns());
-  const estimateSize = useCallback(() => 76, []);
+  const estimateSize = useCallback(() => 100, []);
   const virtualizer = useWindowVirtualizer({
     count: results.length,
     estimateSize,
-    overscan: 30,
+    measureElement: (element) =>
+      element.children[0]?.getBoundingClientRect().height || 0, // The row doesn't have a box, so measure the first cell instead
+    overscan: 20,
   });
   const virtualSize = virtualizer.getTotalSize();
   const virtualItems = virtualizer.getVirtualItems();
-  const paddingTop =
+  const virtualizerPaddingTop =
     virtualItems.length > 0 ? virtualItems?.[0]?.start || 0 : 0;
-  const paddingBottom =
+  const virtualizerPaddingBottom =
     virtualItems.length > 0
       ? virtualSize - (virtualItems?.[virtualItems.length - 1]?.end || 0)
       : 0;
@@ -352,8 +354,8 @@ TableProps<T>): JSX.Element => {
           <GridTable
             gridTemplateColumns={gridTemplateColumns}
             style={{
-              paddingBottom: `${paddingBottom}px`,
-              paddingTop: `${paddingTop}px`,
+              paddingBottom: `${virtualizerPaddingBottom}px`,
+              paddingTop: `${virtualizerPaddingTop}px`,
             }}
           >
             {getHeaderGroups().map((headerGroup) => (
@@ -378,7 +380,11 @@ TableProps<T>): JSX.Element => {
               {virtualItems.map((virtualRow) => {
                 const row = results[virtualRow.index];
                 return (
-                  <TableRow key={row.id}>
+                  <TableRow
+                    key={row.id}
+                    data-index={virtualRow.index}
+                    ref={virtualizer.measureElement}
+                  >
                     {row.getVisibleCells().map((cell) => {
                       return (
                         <TableCell key={cell.id}>


### PR DESCRIPTION
~~One note -- I wasn't sure how best to insert the padding for the virtualization, since it's the whole page's scroll height that needs to be padded, and so in theory the padding could be put anywhere above and below the table contents. Initially I didn't use the window virtualizer and was just virtualizing the table itself, and had to insert extra rows to act as padding, but after switching to the window virtualizer, I ended up putting the padding on the table element, because that allows it to be just CSS padding while otherwise being as close as possible to the table contents.~~

I've realized that when the virtualization can't keep up with the scroll speed, using rows as padding behaves better than putting CSS padding on the table. (When the padding is outside the table contents, the table header might become visible when scrolling upward; also, using a table row as padding means that the empty space has the same white background as the cells in most cases, although for some reason it seems to still sometimes shows the darker background of the table)