### PR TITLE
fix: prevent sending auth token to azul when terra tos not accepted (#395)

### DIFF
--- a/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/AcceptTerraTOS/acceptTerraTOS.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/AcceptTerraTOS/acceptTerraTOS.tsx
@@ -4,13 +4,15 @@ import { ButtonPrimary } from "../../../../../../../../../common/Button/componen
 import { ANCHOR_TARGET } from "../../../../../../../../../Links/common/entities";
 import { FormStep } from "../../formStep";
 
-export interface CreateTerraAccountProps {
-  hasTerraAccount: boolean;
+export interface AcceptTerraTOSProps {
+  disabled: boolean;
+  tosAccepted: boolean;
 }
 
-export const CreateTerraAccount = ({
-  hasTerraAccount,
-}: CreateTerraAccountProps): JSX.Element | null => {
+export const AcceptTerraTOS = ({
+  disabled,
+  tosAccepted,
+}: AcceptTerraTOSProps): JSX.Element | null => {
   const { config } = useConfig();
   const { exportToTerraUrl } = config;
 
@@ -23,14 +25,15 @@ export const CreateTerraAccount = ({
   return (
     <FormStep
       action={<ButtonPrimary onClick={onOpenTerra}>Go to Terra</ButtonPrimary>}
-      completed={hasTerraAccount}
+      completed={tosAccepted}
+      disabled={disabled}
       text={
         <p>
-          Create a Terra account using the same email that you used to log in to
-          data explorer.
+          For full access to the Data Explorer, please sign in to Terra and
+          review and accept the Terra terms of service when prompted.
         </p>
       }
-      title="Create a Terra account"
+      title="Accept the Terra Terms of Service"
     />
   );
 };

--- a/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.tsx
+++ b/packages/data-explorer-ui/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.tsx
@@ -7,6 +7,7 @@ import {
   RoundedPaper,
 } from "../../../../../common/Paper/paper.styles";
 import { SectionTitle } from "../../../../../common/Section/components/SectionTitle/sectionTitle";
+import { AcceptTerraTOS } from "./components/FormStep/components/AcceptTerraTOS/acceptTerraTOS";
 import { ConnectTerraToNIHAccount } from "./components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount";
 import { CreateTerraAccount } from "./components/FormStep/components/CreateTerraAccount/createTerraAccount";
 import { NIHAccountExpiryWarning } from "./components/NIHAccountExpiryWarning/nihAccountExpiryWarning";
@@ -18,6 +19,7 @@ export const TerraSetUpForm = (): JSX.Element | null => {
   const isSetUpComplete =
     isAuthenticated &&
     terraProfile?.hasTerraAccount &&
+    terraProfile?.tosAccepted &&
     NIHProfile?.linkedNIHUsername;
   return !isAuthenticated || !terraProfile ? null : isSetUpComplete ? (
     <NIHAccountExpiryWarning
@@ -39,8 +41,14 @@ export const TerraSetUpForm = (): JSX.Element | null => {
         <CreateTerraAccount
           hasTerraAccount={Boolean(terraProfile?.hasTerraAccount)}
         />
-        <ConnectTerraToNIHAccount
+        <AcceptTerraTOS
           disabled={!terraProfile?.hasTerraAccount}
+          tosAccepted={Boolean(terraProfile?.tosAccepted)}
+        />
+        <ConnectTerraToNIHAccount
+          disabled={
+            !(terraProfile?.hasTerraAccount && terraProfile?.tosAccepted)
+          }
           linkedNIHAccount={Boolean(NIHProfile?.linkedNIHUsername)}
         />
       </GridPaper>

--- a/packages/data-explorer-ui/src/providers/authentication.tsx
+++ b/packages/data-explorer-ui/src/providers/authentication.tsx
@@ -270,7 +270,7 @@ export function AuthProvider({ children, sessionTimeout }: Props): JSX.Element {
         isAuthenticated,
         requestAuthentication,
         terraProfile,
-        token,
+        token: terraProfile?.tosAccepted ? token : undefined,
         userProfile,
       }}
     >


### PR DESCRIPTION
Closes #395.
Addresses https://github.com/DataBiosphere/data-browser/issues/3593.