### PR TITLE
feat: add tooltip when filter tag label is truncated (#438)

### DIFF
--- a/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
@@ -1,6 +1,7 @@
 import { CloseRounded } from "@mui/icons-material";
-import { Chip } from "@mui/material";
+import { Chip, Tooltip } from "@mui/material";
 import React from "react";
+import { useWindowResize } from "../../../../hooks/useWindowResize";
 import { SupersededTag } from "./filterTag.styles";
 
 export interface FilterTagProps {
@@ -15,15 +16,27 @@ export const FilterTag = ({
   superseded,
 }: FilterTagProps): JSX.Element => {
   const Tag = superseded ? SupersededTag : Chip;
+  const tagRef = React.useRef<HTMLDivElement>(null);
+  const windowSize = useWindowResize();
+  const [isOverflowed, setIsOverflowed] = React.useState(false);
+  React.useEffect(() => {
+    const tagLabelElement =
+      tagRef.current?.querySelector<HTMLElement>(".MuiChip-label");
+    if (!tagLabelElement) return;
+    setIsOverflowed(tagLabelElement.offsetWidth < tagLabelElement.scrollWidth);
+  }, [windowSize]);
   return (
-    <Tag
-      clickable={false} // removes unwanted active and hover ui; "pointer" cursor added to "filterTag" variant in theme.
-      color="primary"
-      deleteIcon={<CloseRounded color="inherit" />}
-      label={label}
-      onClick={onRemove}
-      onDelete={onRemove}
-      variant="filterTag"
-    />
+    <Tooltip arrow placement="top" title={isOverflowed ? label : null}>
+      <Tag
+        clickable={false} // removes unwanted active and hover ui; "pointer" cursor added to "filterTag" variant in theme.
+        color="primary"
+        deleteIcon={<CloseRounded color="inherit" />}
+        label={label}
+        onClick={onRemove}
+        onDelete={onRemove}
+        ref={tagRef}
+        variant="filterTag"
+      />
+    </Tooltip>
   );
 };

--- a/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
@@ -1,6 +1,6 @@
 import { CloseRounded } from "@mui/icons-material";
 import { Chip, Tooltip } from "@mui/material";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useWindowResize } from "../../../../hooks/useWindowResize";
 import { SupersededTag } from "./filterTag.styles";
 
@@ -16,10 +16,10 @@ export const FilterTag = ({
   superseded,
 }: FilterTagProps): JSX.Element => {
   const Tag = superseded ? SupersededTag : Chip;
-  const tagRef = React.useRef<HTMLDivElement>(null);
+  const tagRef = useRef<HTMLDivElement>(null);
   const windowSize = useWindowResize();
-  const [isOverflowed, setIsOverflowed] = React.useState(false);
-  React.useEffect(() => {
+  const [isOverflowed, setIsOverflowed] = useState(false);
+  useEffect(() => {
     const tagLabelElement =
       tagRef.current?.querySelector<HTMLElement>(".MuiChip-label");
     if (!tagLabelElement) return;

--- a/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
@@ -1,7 +1,6 @@
 import { CloseRounded } from "@mui/icons-material";
 import { Chip, Tooltip } from "@mui/material";
 import React, { useEffect, useRef, useState } from "react";
-import { useWindowResize } from "../../../../hooks/useWindowResize";
 import { SupersededTag } from "./filterTag.styles";
 
 export interface FilterTagProps {
@@ -10,6 +9,19 @@ export interface FilterTagProps {
   superseded: boolean;
 }
 
+const DEFAULT_SLOT_PROPS = {
+  popper: {
+    modifiers: [
+      {
+        name: "offset",
+        options: {
+          offset: [0, -6],
+        },
+      },
+    ],
+  },
+};
+
 export const FilterTag = ({
   label,
   onRemove,
@@ -17,16 +29,21 @@ export const FilterTag = ({
 }: FilterTagProps): JSX.Element => {
   const Tag = superseded ? SupersededTag : Chip;
   const tagRef = useRef<HTMLDivElement>(null);
-  const windowSize = useWindowResize();
   const [isOverflowed, setIsOverflowed] = useState(false);
   useEffect(() => {
     const tagLabelElement =
       tagRef.current?.querySelector<HTMLElement>(".MuiChip-label");
     if (!tagLabelElement) return;
     setIsOverflowed(tagLabelElement.offsetWidth < tagLabelElement.scrollWidth);
-  }, [windowSize]);
+  }, []);
   return (
-    <Tooltip arrow placement="top" title={isOverflowed ? label : null}>
+    <Tooltip
+      arrow
+      disableInteractive
+      placement="top"
+      slotProps={DEFAULT_SLOT_PROPS}
+      title={isOverflowed ? label : null}
+    >
       <Tag
         clickable={false} // removes unwanted active and hover ui; "pointer" cursor added to "filterTag" variant in theme.
         color="primary"

--- a/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
+++ b/packages/data-explorer-ui/src/components/Filter/components/FilterTag/filterTag.tsx
@@ -1,6 +1,6 @@
 import { CloseRounded } from "@mui/icons-material";
 import { Chip, Tooltip } from "@mui/material";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef } from "react";
 import { SupersededTag } from "./filterTag.styles";
 
 export interface FilterTagProps {
@@ -29,13 +29,10 @@ export const FilterTag = ({
 }: FilterTagProps): JSX.Element => {
   const Tag = superseded ? SupersededTag : Chip;
   const tagRef = useRef<HTMLDivElement>(null);
-  const [isOverflowed, setIsOverflowed] = useState(false);
-  useEffect(() => {
-    const tagLabelElement =
-      tagRef.current?.querySelector<HTMLElement>(".MuiChip-label");
-    if (!tagLabelElement) return;
-    setIsOverflowed(tagLabelElement.offsetWidth < tagLabelElement.scrollWidth);
-  }, []);
+  const tagLabelElement =
+    tagRef.current?.querySelector<HTMLElement>(".MuiChip-label");
+  const isOverflowed =
+    (tagLabelElement?.offsetWidth ?? 0) < (tagLabelElement?.scrollWidth ?? 0);
   return (
     <Tooltip
       arrow


### PR DESCRIPTION
~~Currently a draft because @NoopDog mentioned that we might need to determine how big the gap between the tooltip and the tag should be~~

~~Additionally: Is `useWindowResize` a good way of determining when to re-check whether the tag label is overflowing? Are there other situations in which that might change? Or, conversely, is there a simpler set of circumstances in which it can?~~